### PR TITLE
added hint text and lists to relevant screens

### DIFF
--- a/app/views/departures/version-2/goods-summary/loading-place.html
+++ b/app/views/departures/version-2/goods-summary/loading-place.html
@@ -22,6 +22,9 @@ Where is the loading place?
   label: {
     text: ""
   },
+  hint: {
+    text: "This is where the goods are loaded onto the vehicle that will transport them."
+  },
   id: "loading-place",
   classes: "govuk-input--width-20",
   name: "loading-place"

--- a/app/views/departures/version-2/guarantee/liability-amount.html
+++ b/app/views/departures/version-2/guarantee/liability-amount.html
@@ -23,7 +23,7 @@ What is the liability amount?
             classes: "govuk-input--width-10",
             autocomplete: "off",
             type: "tel"
-            })
+          })
         }}
 
       {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/app/views/departures/version-2/overview/office-of-departure.html
+++ b/app/views/departures/version-2/overview/office-of-departure.html
@@ -19,6 +19,9 @@ What is the office of departure?
 
       {{ govukInput({
         classes: "govuk-input--width-20",
+          hint: {
+    text: "This is the customs office where the goods will be loaded onto the vehicle being used to transport them."
+  },
         id: "office-of-departure",
         name: "office-of-departure"
       }) }}

--- a/app/views/departures/version-2/overview/place-of-declaration.html
+++ b/app/views/departures/version-2/overview/place-of-declaration.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Where is the place of declaration?
+Where are you making this declaration?
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,8 +13,13 @@ Where is the place of declaration?
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Where is the place of declaration?</h1>
-
+    <h1 class="govuk-heading-xl">Where are you making this declaration?</h1>
+<p class="govuk-body"><p>Do not include:</p>
+<ul class="govuk-list govuk-list--bullet">
+<li>the office of despatch</li>
+<li>any offices of transit</li>
+<li>the office of destination</li>
+</ul>
     <form action="making-declaration-on-behalf-of-someone-else" class="form" method="post">
 
       {{ govukInput({


### PR DESCRIPTION
Had to find nunjucks for hint texts and lists, have updated:

- Overview > office-of-departure
- Overview > place-of-declaration
- Guarantee > liability-amount
- Goods summary > loading-place
- Trader summary > trader-details